### PR TITLE
remove default wendigo query param

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -80,9 +80,6 @@ class Client {
         bool $force = false,
         int $secondsUntilExpires = self::THIRTY_DAYS
     ): RenderResult {
-        // default wendigo to true. job handling code should force this to false, so false postives aren't reported
-        $queryParams = array_merge(['wendigo' => true], $queryParams);
-
         if (is_array($props)) {
             $this->ksortRecursive($props);
             $propsAsString = json_encode($props);


### PR DESCRIPTION
Based on changes in https://github.com/coursehero/theia/pull/2 we can remove the default wendigo query param in the sdk